### PR TITLE
fix(http_client): 修复 relay_timeout 的默认值和条件判断 （#567）

### DIFF
--- a/common/requester/http_client.go
+++ b/common/requester/http_client.go
@@ -18,8 +18,8 @@ func InitHttpClient() {
 		Transport: trans,
 	}
 
-	relayTimeout := utils.GetOrDefault("relay_timeout", 600)
-	if relayTimeout != 0 {
+	relayTimeout := utils.GetOrDefault("relay_timeout", 0)
+	if relayTimeout > 0 {
 		HTTPClient.Timeout = time.Duration(relayTimeout) * time.Second
 	}
 }


### PR DESCRIPTION
- 将 relay_timeout 的默认值修改为 0，确保只有在大于 0 时才设置 HTTPClient 的超时时间。
- 优化条件判断逻辑，提高代码的可读性和健壮性。

[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
